### PR TITLE
Bump to version 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "event-dispatcher"
-version="0.4.0"
 description = "An event dispatcher for Python"
 authors = [
     {name = "Valentin Ambroise", email = "valentin.ambroise@outlook.com"}
 ]
 requires-python = ">=3.9"
 license = {file = "LICENSE"}
+dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
@@ -28,6 +28,9 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.dynamic]
+version = {attr = "dispatcher.__version__"}
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "session"

--- a/src/dispatcher/__init__.py
+++ b/src/dispatcher/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "0.5.0"
+
 from .ABC import AsyncDispatcher, context, Dispatcher, STOP_SIGNAL
 from .async_amqp_dispatcher import AsyncAMQPDispatcher
 from .async_in_memory_dispatcher import AsyncInMemoryDispatcher


### PR DESCRIPTION
* Breaking change

- Distribute `Messages` with room set to `None` to all the dispatchers connected to the namespace

* Major changes

- Drop support for CPython 3.7 and 3.8

- Add a "timeout" parameter to `emit` methods

- Allow sessions identifier to be any hashable object possible

- Properly support bytes payload

- Add a CI/CD workflow

* Minor changes

- Expose `dispatcher` in `{Async}EventHandler`

- Various improvements to AMQP-based dispatchers